### PR TITLE
Put work on thread pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - A complete example app based on the [order-process workflow from Zeebe's "Getting Started Tutorial"][order_process].
+### Changed
+- `Sync + UnwindSafe` is now enforced on job handlers and all work is done on a threadpool with `futures-cpupool`.
 
 ## [0.18.0] - 2019-06-10
 Initial release of zeebest 🥏

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "atomic-counter 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust-grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 [dependencies]
 failure = "0.1.5"
 futures = "0.1.27"
+futures-cpupool = "0.1.8"
 grpc = "0.6.1"
 protobuf = "2"
 serde = "1.0.91"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ its best to only request jobs from the broker up to the maximum amount. Each job
 Workers currently will only poll the gateway manually, so you will need to use another system to process jobs periodically. 
 `tokio::Interval` does a pretty good job of this.
 
+All work is put on to a thread-pool with the help of [`futures-cpupool` crate][futures_cpupool] so that the job handlers
+do not block the event loop.
+
 ```rust
-let client = Client::new("127.0.0.1", 26500).unwrap();
+let mut client = Client::new("127.0.0.1", 26500).unwrap();
 
 let handler = move |activated_job| { 
     Ok(JobResult::Complete { variables: None })
@@ -93,3 +96,4 @@ the completeness.
 [docker_compose]: https://github.com/zeebe-io/zeebe-docker-compose
 [java_client]: https://github.com/zeebe-io/zeebe/tree/develop/clients/java/src/main/java/io/zeebe/client
 [order_process]: examples/order_process_app.rs
+[futures_cpupool]: https://crates.io/crates/futures-cpupool

--- a/examples/order_process_app.rs
+++ b/examples/order_process_app.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 use tokio::timer::Interval;
 use zeebest::{Client, JobResult, PanicOption, PublishMessage, WorkflowInstance, WorkflowVersion};
+use std::thread::sleep;
 
 #[derive(StructOpt, Debug)]
 #[structopt(
@@ -103,6 +104,7 @@ fn main() {
                 4,
                 PanicOption::FailJobOnPanic,
                 move |_| {
+                    sleep(Duration::from_secs(5));
                     Ok({
                         // increment the order id counter
                         // this would normally be a key in a database or something

--- a/examples/order_process_app.rs
+++ b/examples/order_process_app.rs
@@ -5,11 +5,11 @@ use atomic_counter::{AtomicCounter, RelaxedCounter};
 use futures::stream::Stream;
 use futures::Future;
 use std::sync::Arc;
+use std::thread::sleep;
 use std::time::Duration;
 use structopt::StructOpt;
 use tokio::timer::Interval;
 use zeebest::{Client, JobResult, PanicOption, PublishMessage, WorkflowInstance, WorkflowVersion};
-use std::thread::sleep;
 
 #[derive(StructOpt, Debug)]
 #[structopt(

--- a/examples/order_process_app.rs
+++ b/examples/order_process_app.rs
@@ -55,7 +55,7 @@ struct Payment {
 }
 
 fn main() {
-    let client = Client::new("127.0.0.1", 26500).expect("Could not connect to broker.");
+    let mut client = Client::new("127.0.0.1", 26500).expect("Could not connect to broker.");
 
     let opt = Opt::from_args();
     match opt {

--- a/examples/simple_failing_worker.rs
+++ b/examples/simple_failing_worker.rs
@@ -6,7 +6,7 @@ use zeebest::{Client, JobResult, PanicOption};
 
 fn main() {
     // put the client in an Arc because it will be used on different threads
-    let client = Client::new("127.0.0.1", 26500).unwrap();
+    let mut client = Client::new("127.0.0.1", 26500).unwrap();
 
     // this is your work function - this one always panics!
     let handler = move |_payload| {

--- a/examples/simple_worker.rs
+++ b/examples/simple_worker.rs
@@ -5,7 +5,7 @@ use tokio::timer::Interval;
 use zeebest::{Client, JobResult, PanicOption};
 
 fn main() {
-    let client = Client::new("127.0.0.1", 26500).unwrap();
+    let mut client = Client::new("127.0.0.1", 26500).unwrap();
 
     let handler = move |_payload| Ok(JobResult::Complete { variables: None });
 


### PR DESCRIPTION
This is the first-pass at moving work off the main thread and onto a thread pool. There are new restrictions on the job-handlers like `Sync` and `UnwindSafe`. These were necessary to get this completed, but it's possible these restrictions may go away in the future. Stateless job handlers is the most common use case, so this tradeoff is ok for now. 

Addresses #15 