### PR TITLE
More activated job data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - A complete example app based on the [order-process workflow from Zeebe's "Getting Started Tutorial"][order_process].
+- The job stream now returns the completed `ActivatedJob` struct instead of just the job key. 
 ### Changed
 - `Sync + UnwindSafe` is now enforced on job handlers and all work is done on a threadpool with `futures-cpupool`.
 

--- a/examples/simple_failing_worker.rs
+++ b/examples/simple_failing_worker.rs
@@ -31,7 +31,7 @@ fn main() {
             worker
                 .activate_and_process_jobs()
                 .and_then(|(result, key)| {
-                    println!("processed {} with result: {:?}", key, result);
+                    println!("processed {:?} with result: {:?}", key, result);
                     Ok(())
                 })
                 .collect()

--- a/examples/simple_worker.rs
+++ b/examples/simple_worker.rs
@@ -24,8 +24,8 @@ fn main() {
         .and_then(move |_| {
             worker
                 .activate_and_process_jobs()
-                .and_then(|(result, key)| {
-                    println!("processed {} with result: {:?}", key, result);
+                .and_then(|(result, activated_job)| {
+                    println!("processed {} with result: {:?}", activated_job.key, result);
                     Ok(())
                 })
                 .collect()


### PR DESCRIPTION
This PR adds to the job stream result. It now contains the whole activated job data instead of just the job key. 

Fixes #12 